### PR TITLE
Kürze Postskriptum Tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ address:
 opening: Sehr geehrte Damen und Herren,
 closing: Mit freundlichen Grüßen
 encludes: Muster, Muster, Muster
+ps: |
+   \textbf{Postskriptum \today}
+
+   Noch ein Gedanke zum Schluss.
 ...
 ```
 
@@ -71,6 +75,7 @@ The following yaml variables are supported:
 - `opening`
 - `closing`
 - `encludes`
+- `ps`
 - `author`
 - `phone`
 - `email`

--- a/example/letter.md
+++ b/example/letter.md
@@ -16,6 +16,10 @@ address:
 opening: Sehr geehrte Damen und Herren,
 closing: Mit freundlichen Grüßen
 encludes: Muster, Muster, Muster
+ps: |
+   \textbf{Postskriptum \today}
+
+   Noch ein Gedanke zum Schluss.
 ...
 Far far away, behind the word mountains, far from the countries
 Vokalia and Consonantia, there live the blind texts. Separated

--- a/letter.latex
+++ b/letter.latex
@@ -59,7 +59,7 @@
 
         \closing{$closing$}
 
-        \ps $postskriptum$
+        \ps $ps$
 
         $if(encludes)$
             \setkomavar*{enclseparator}{Anlage}


### PR DESCRIPTION
Alles andere Tags sind in English (das wäre dann `postscriptum`) und das lange Wort ist unnötig lang.