### PR TITLE
KOMA-Script doesn't require parskip package.

### DIFF
--- a/letter.latex
+++ b/letter.latex
@@ -5,14 +5,13 @@
     fromphone,           % show phone number
     fromemail,           % show email
     fromlogo,            % show logo in letter head
+    parskip=half,        % no parindent, but parskip
     version=last         % latest version of KOMA letter
 ]{scrlttr2}
 
 \usepackage[ngerman]{babel}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
-
-\usepackage{parskip}
 
 \usepackage{graphics}
 


### PR DESCRIPTION
Instead, scrlttr2 issues the following warning:
```
Class scrlttr2 Warning: Usage of package `parskip' together
(scrlttr2)              with a KOMA-Script class is not recommended.
(scrlttr2)              I'd suggest to use option
(scrlttr2)              `parskip' with one of it's several values.
(scrlttr2)              Nevertheless, using requested
(scrlttr2)              package `parskip' on input line 16.
```