### PR TITLE
Rename tag for enclosure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ address:
  - 12345 Musterstadt
 opening: Sehr geehrte Damen und Herren,
 closing: Mit freundlichen Grüßen
-encludes: Muster, Muster, Muster
+enclosed: Muster, Muster, Muster
 ...
 ```
 
@@ -70,7 +70,7 @@ The following yaml variables are supported:
 
 - `opening`
 - `closing`
-- `encludes`
+- `enclosed`
 - `author`
 - `phone`
 - `email`

--- a/example/letter.md
+++ b/example/letter.md
@@ -15,7 +15,7 @@ address:
  - 12345 Musterstadt
 opening: Sehr geehrte Damen und Herren,
 closing: Mit freundlichen Grüßen
-encludes: Muster, Muster, Muster
+enclosed: Muster, Muster, Muster
 ...
 Far far away, behind the word mountains, far from the countries
 Vokalia and Consonantia, there live the blind texts. Separated

--- a/letter.latex
+++ b/letter.latex
@@ -61,9 +61,9 @@
 
         \ps $postskriptum$
 
-        $if(encludes)$
+        $if(enclosed)$
             \setkomavar*{enclseparator}{Anlage}
-            \encl{$encludes$}
+            \encl{$enclosed$}
         $endif$
     \end{letter}
 \end{document}


### PR DESCRIPTION
Although `encludes` is valid, albeit out-dated, `enclosed` matches the formal nomination.